### PR TITLE
Add refs to stratus red team implementations of AZT301-1 and AZT301-2

### DIFF
--- a/docs/Execution/AZT301/AZT301-1.md
+++ b/docs/Execution/AZT301/AZT301-1.md
@@ -52,3 +52,4 @@ By utilizing the 'RunCommand' feature on a Virtual Machine, an attacker can pass
 
 	* [https://docs.microsoft.com/en-us/azure/virtual-machines/windows/run-command](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/run-command)
 	* [https://docs.microsoft.com/en-us/azure/virtual-machines/linux/run-command](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/run-command)
+	* [https://stratus-red-team.cloud/attack-techniques/azure/azure.execution.vm-run-command/](https://stratus-red-team.cloud/attack-techniques/azure/azure.execution.vm-run-command/)

--- a/docs/Execution/AZT301/AZT301-2.md
+++ b/docs/Execution/AZT301/AZT301-2.md
@@ -45,3 +45,4 @@ By utilizing the 'CustomScriptExtension' extension on a Virtual Machine, an atta
 
 	* [https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-windows](https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-windows)
 	* [https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-linux](https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/custom-script-linux)
+	* [https://stratus-red-team.cloud/attack-techniques/azure/azure.execution.vm-custom-script-extension/](https://stratus-red-team.cloud/attack-techniques/azure/azure.execution.vm-custom-script-extension/)


### PR DESCRIPTION
**What**

Added links to the [Stratus Red Team](https://stratus-red-team.cloud/) implementations of the RunCommand and CustomScriptExtension techniques. 

**Why**

- Stratus allows researchers to quickly reproduce the relevant techniques. This benefits the community and demonstrates the TTPs/artifacts documented in ATRM.
- The stratus docs have already been updated to point to ATRM, so this is basically a back-link.