### PR TITLE
Add AZT606/AZT607/AZT304

### DIFF
--- a/docs/CredentialAccess/AZT606/AZT606-1.md
+++ b/docs/CredentialAccess/AZT606/AZT606-1.md
@@ -1,0 +1,83 @@
+# AZT606.1 - Steal App Service Easy Auth Tokens: App Service Token File Decryption (Kudu)
+
+An attacker with the ability to run commands in an App Service container or read environment variables can retrieve the Easy Auth token cache from the App Service filesystem and decrypt it using the application’s Easy Auth encryption key. Kudu (the App Service SCM site) exposes APIs such as `/api/command`, `/api/env`, and `/api/vfs` that facilitate command execution and file access when authenticated.
+
+**Resource**  
+App Service
+
+**Permissions / Preconditions**
+
+- Ability to access the App Service SCM/Kudu site with sufficient rights to execute commands or read files (commonly via a role such as **Contributor** on the App Service).
+- Easy Auth enabled with the default filesystem token cache (or another accessible token store).
+- Network access to the `{site}.scm.azurewebsites.net` endpoint (SCM site).
+
+**Token Store Locations (default filesystem cache)**
+
+- Linux: `/home/data/.auth/tokens`
+- Windows: `C:\home\data\.auth\tokens`
+
+**Key Material**
+
+- `WEBSITE_AUTH_ENCRYPTION_KEY` — Easy Auth token encryption key stored as an app setting / environment variable.
+
+**Procedure (High Level)**
+
+1. Determine that Easy Auth is enabled on the target App Service.
+2. Use the Kudu/SCM site to:
+   - List/read environment variables to obtain `WEBSITE_AUTH_ENCRYPTION_KEY` (e.g., `GET https://{site}.scm.azurewebsites.net/api/env`).
+   - Enumerate and read encrypted token JSON files from the token store directories (e.g., `GET https://{site}.scm.azurewebsites.net/api/vfs/home/data/.auth/tokens/`).
+3. Decrypt the token cache entries using the application’s Easy Auth encryption key to recover user tokens (ID/access/refresh where present).
+4. Use recovered tokens to access the application and/or downstream APIs as the victim user, within the tokens’ scopes and lifetimes.
+
+**Examples**
+
+- **Tooling**: NetSPI’s `Get-AzWebAppTokens` (part of MicroBurst) automates enumeration, Kudu interactions, token file collection, and decryption.
+- **Indicative API paths** (SCM/Kudu):
+  - `POST https://{site}.scm.azurewebsites.net/api/command`
+  - `GET  https://{site}.scm.azurewebsites.net/api/env`
+  - `GET  https://{site}.scm.azurewebsites.net/api/vfs/home/data/.auth/tokens/`
+
+**Detections**
+
+*Logs*
+
+Data Source | Operation / Indicator | Action | Log Provider
+---|---|---|---
+SCM/Kudu HTTP | Requests to `{site}.scm.azurewebsites.net` with paths like `/api/command`, `/api/env`, `/api/vfs/.../.auth/tokens` | N/A | AppServiceHTTPLogs (Azure Monitor / Diagnostic Settings)
+Azure Activity (context) | Configuration changes enabling diagnostics or starting/stopping the site | Microsoft.Web/* | AzureActivity
+
+*Queries (KQL examples)*
+
+- **Kudu command/file access (HTTP)**  
+  Looks for SCM requests to command/env/VFS endpoints:
+  ```kusto
+  AppServiceHTTPLogs
+  | where CsHost endswith ".scm.azurewebsites.net"
+  | where CsUriStem has_any("/api/command", "/api/env", "/api/vfs")
+  | project TimeGenerated, CsHost, CsMethod, CsUriStem, ScStatus, UserAgent, _ResourceId
+  | order by TimeGenerated desc
+  ```
+
+- **Direct token-store browsing via VFS**  
+  ```kusto
+  AppServiceHTTPLogs
+  | where CsHost endswith ".scm.azurewebsites.net"
+  | where CsUriStem has "/api/vfs" and CsUriStem has "/.auth/tokens"
+  | summarize count() by bin(TimeGenerated, 1h), CsHost
+  ```
+
+**Mitigations**
+
+- **Restrict SCM/Kudu access**: Apply **Access Restrictions** specifically to the **advanced tools (scm) site** to limit who can reach Kudu (e.g., IP allow-lists, private endpoints, VNets).
+- **Least privilege**: Avoid broad **Contributor** grants on App Services; prefer narrowly scoped roles and separate operational identities.
+- **Protect token encryption key**: Treat `WEBSITE_AUTH_ENCRYPTION_KEY` as sensitive secret material; rotate it after suspected exposure.
+- **Monitoring**: Enable AppServiceHTTPLogs to Log Analytics; alert on suspicious SCM paths (`/api/command`, `/api/env`, `/api/vfs/.../.auth/tokens`).
+
+**Additional Resources**
+
+- NetSPI: Automating Azure App Services Token Decryption — https://www.netspi.com/blog/technical-blog/cloud-pentesting/automating-azure-app-services-token-decryption/
+- MicroBurst `Get-AzWebAppTokens` — https://github.com/NetSPI/MicroBurst/blob/master/Azure/Get-AzWebAppTokens.ps1
+- Daze Security: Easy Auth token cache & decryption background — https://www.daze.one/blog/stealing-azure-app-service-easy-auth-tokens
+- Microsoft Docs: Kudu / Azure App Service advanced tools — https://learn.microsoft.com/azure/app-service/resources-kudu
+- Microsoft Docs: AppServiceHTTPLogs table — https://learn.microsoft.com/azure/azure-monitor/reference/tables/appservicehttplogs
+- Microsoft Docs: App Service access restrictions (main & SCM) — https://learn.microsoft.com/azure/app-service/app-service-ip-restrictions

--- a/docs/CredentialAccess/AZT606/AZT606.md
+++ b/docs/CredentialAccess/AZT606/AZT606.md
@@ -1,0 +1,9 @@
+# AZT606 - Steal App Service Easy Auth Tokens
+
+> Note: **AZT606** is a placeholder family ID for this proposal. The maintainers may renumber or relocate this entry during review.
+
+An adversary may obtain user tokens from Azure App Service’s built-in Authentication/Authorization (“Easy Auth”) token cache. When Easy Auth is enabled, user tokens (ID, access, and optionally refresh tokens) can be cached by the middleware and stored on the App Service filesystem (default) or in a configured external store. If an attacker can read the token store and the corresponding encryption material, they can decrypt tokens and impersonate users against downstream APIs or the application itself.
+
+ID | Name | Description | Action | Resources
+---|---|---|---|---
+AZT606.1 | App Service Token File Decryption (Kudu) | Use Kudu/SCM command execution or APIs to read Easy Auth token files from the App Service filesystem, retrieve the encryption key from environment/app settings, and decrypt the tokens. | N/A (SCM/Kudu HTTP APIs) | App Service

--- a/docs/CredentialAccess/AZT607/AZT607-1.md
+++ b/docs/CredentialAccess/AZT607/AZT607-1.md
@@ -1,0 +1,75 @@
+# AZT607.1 - Extract Azure Load Testing Secrets and Tokens: JMeter/Locust Code Execution
+
+**Resource**  
+Azure Load Testing
+
+**Summary**
+
+Azure Load Testing supports uploading JMeter **JMX** or **Locust** test scripts. JMX allows embedded objects such as **JSR223Sampler** (Groovy) or **BeanShell**, and Locust scripts are standard Python. When these tests execute, the worker process can access:
+
+- **Managed Identity** tokens via the Instance Metadata Service (IMDS) for the Load Testing resource’s assigned MI.
+- **Secrets** injected as **environment variables** for the test (for example, API keys/credentials passed as parameters).
+- **Certificates** provided to the test runner (stored on disk).
+
+**Known default locations (as documented by research and Microsoft docs)**
+
+- Secrets: exposed to the test as **environment variables**.
+- Certificates (Locust): path indicated by the `ALT_CERTIFICATES_DIR` environment variable (commonly `/root/artifacts/certs/`).
+- Certificates (JMeter): typically under `/jmeter/bin/` within the runner container.
+
+**Permissions / Preconditions**
+
+- Ability to create or modify and run tests in the target Azure Load Testing resource (e.g., **Contributor** on the resource or equivalent delegated access). Exact role requirements depend on tenant configuration.
+- Managed Identity must be enabled to obtain MI tokens (if token extraction is a goal).
+- Secrets/certificates must be configured for the tests (if secret extraction is a goal).
+
+**Procedure (High Level)**
+
+1. **Prepare malicious test content**:  
+   - JMeter: add a `JSR223Sampler` executing Groovy to run commands and read env/files (e.g., `whoami`, reading env vars, listing cert paths).  
+   - Locust: embed Python code to read env/files and make HTTP requests.
+2. **Execute in Azure Load Testing**: upload and run the test in the target resource.
+3. **Extract data**:
+   - Enumerate environment variables and read certificate files.  
+   - Query IMDS for a token using the resource’s Managed Identity (standard Azure IMDS endpoint).  
+   - If HTTP responses aren’t directly observable in results, use the approach from research: start a local HTTP listener within the worker and have the test send requests to it so that outputs appear in the **test results zip** collected by the service.
+4. **Collect artifacts**: download the **results zip** from the run and parse the CSV/logs to recover exfiltrated data; optionally save certificate files.
+
+**Automation Example (Public Tooling)**
+
+- **MicroBurst** function `Get-AzLoadTestingData` automates: enumeration of Load Testing resources and tests; scraping test settings for secrets/certificates/variables; creating a new test; running a data collection routine; downloading and parsing the results zip; and optional saving of certificates.
+
+**Detections**
+
+*Notes*: The Microsoft **Activity Log** did **not** provide sufficient telemetry in testing; enabling **Diagnostic Logs** for Azure Load Testing was required to observe relevant operations. The following operation names/IDs were observed by researchers (names may evolve; validate in your tenant):
+
+Data Source | Indicator | Operation / Details
+---|---|---
+Azure Load Testing Diagnostic Logs | Listing tests | `MICROSOFT.LOADTESTSERVICE/LOADTESTS/READTEST/ACTION` (`LoadTestAdministration_ListTests`, `GET`)
+Azure Load Testing Diagnostic Logs | Reading test details | `MICROSOFT.LOADTESTSERVICE/LOADTESTS/READTEST/ACTION` (`LoadTestAdministration_GetTest`, `GET`)
+Azure Load Testing Diagnostic Logs | Deleting a test (cleanup) | `MICROSOFT.LOADTESTSERVICE/LOADTESTS/DELETETEST/ACTION` (`LoadTestAdministration_DeleteTest`, `DELETE`)
+Azure Load Testing Diagnostic Logs | Results ZIP retrieval | **Not logged** in research notes (URL is external but referenced in GetTest output)
+
+*Query ideas (adjust table names to your workspace schema)*
+
+```text
+-- Example pseudo-KQL: search Load Testing Diagnostic Logs for suspicious test admin activity
+LoadTestingDiagnostics
+| where OperationName has_any ("READTEST", "DELETETEST")
+| project TimeGenerated, OperationName, OperationId, RequestUri, Caller, _ResourceId
+```
+
+**Mitigations**
+
+- **Least privilege**: restrict who can create/modify tests on Azure Load Testing; avoid broad Contributor on the resource.
+- **Secrets hygiene**: prefer short-lived credentials; use Key Vault references and scope MI permissions minimally; rotate secrets regularly.
+- **Network and policy controls**: consider **private network injection** for Load Testing and limit egress; use **Azure Policy** to audit/deny risky configurations (e.g., enforcing private endpoints for tests as applicable).
+- **Logging**: enable **Diagnostic Settings** for Azure Load Testing to Log Analytics and alert on unusual test creation/reads and unexpected test content.
+
+**Additional Resources**
+
+- NetSPI: *Extracting Sensitive Information from Azure Load Testing* – https://www.netspi.com/blog/technical-blog/cloud-pentesting/extracting-sensitive-information-azure-load-testing/
+- MicroBurst `Get-AzLoadTestingData` – https://github.com/NetSPI/MicroBurst/blob/master/Az/Get-AzLoadTestingData.ps1
+- Microsoft Docs: *Use secrets & environment variables in Azure Load Testing* – https://learn.microsoft.com/azure/app-testing/load-testing/how-to-parameterize-load-tests
+- Microsoft Docs: *Load test authenticated endpoints* – https://learn.microsoft.com/azure/app-testing/load-testing/how-to-test-secured-endpoints
+- Microsoft Docs: *Use Azure Policy with Azure Load Testing* – https://learn.microsoft.com/azure/app-testing/load-testing/how-to-use-azure-policy

--- a/docs/CredentialAccess/AZT607/AZT607.md
+++ b/docs/CredentialAccess/AZT607/AZT607.md
@@ -1,0 +1,15 @@
+[AZT607.md](https://github.com/user-attachments/files/22000720/AZT607.md)
+# AZT607 - Extract Azure Load Testing Secrets and Tokens
+
+> Note: **AZT607** is a placeholder family ID for this proposal. Maintainers may renumber or relocate this entry.
+
+An adversary with write access to an **Azure Load Testing** resource can configure/load test scripts (JMeter **JMX** or **Locust** Python) that execute code within the Load Testing worker. This execution context can access:
+
+- **Managed Identity** (MI) metadata endpoint to obtain access tokens for the Load Testing resource’s assigned identity.
+- **Secrets and certificates** that Azure Load Testing injects for test runs (secrets as **environment variables**; certificates on disk for the test runner).
+
+With code execution in the test plan, an attacker can enumerate and exfiltrate these values from the worker and impersonate identities or access downstream resources authorized by those credentials.
+
+ID | Name | Description | Action | Resources
+---|---|---|---|---
+AZT607.1 | JMeter/Locust Code Execution to Extract Secrets/Tokens | Abuse JMX JSR223/BeanShell or Locust Python to run code, enumerate environment variables and certificate files, and query IMDS for MI tokens during Azure Load Testing runs. | N/A (test plan execution) | Azure Load Testing

--- a/docs/Execution/AZT304/AZT304-1.md
+++ b/docs/Execution/AZT304/AZT304-1.md
@@ -1,0 +1,74 @@
+# AZT304.1 - Hijack Azure Machine Learning Notebooks: Storage Account Notebook Overwrite
+
+**Resource**  
+Azure Machine Learning (workspace, compute), Azure Storage Account (Azure Files)
+
+**Summary**
+
+AML stores notebooks on an associated Storage Account (file share commonly exposed as **code**). AML Studio presents these files in the notebook UI. With write access to the Storage Account, an attacker can edit a target `.ipynb` and insert a malicious **code cell** (optionally hidden in UI metadata). When a user runs all cells or an automated pipeline executes, the injected code runs on the AML **compute instance/cluster** with that session’s privileges (user context and/or Managed Identity).
+
+**Preconditions / Permissions**
+
+- **Write access** to the AML workspace’s **Storage Account file share** that stores notebooks (e.g., Storage Account Contributor, File Data SMB Share Elevated Contributor, or possession of **account keys/SAS**).
+- To pivot into AML credentials: **Write** on AML workspace (for listKeys on certain endpoints) or equivalent permissions as applicable in current service behavior.
+- Target notebook is executed by a user or as part of a pipeline/schedule.
+
+**Where Notebooks Live**
+
+- AML workspace’s **backing Storage Account** (named similar to `<workspace><digits>`).  
+- **Azure Files** share (commonly `code`) contains `.ipynb` notebooks and user files.
+
+**Procedure (High Level)**
+
+1. Identify the AML workspace’s associated **Storage Account** and its **Azure Files** share hosting notebooks (e.g., `code`).  
+2. Obtain write access (RBAC on Storage, account keys via management/data plane, or existing credentials).  
+3. **Edit** a target `.ipynb` in the file share: add a new code cell (e.g., `! whoami`, token collection, exfiltration). Mark it hidden via notebook metadata if desired.  
+4. Wait for a user to click **Run all** or for an **automated pipeline** execution to process the notebook.  
+5. Use outputs or an **exfiltration channel** (HTTP/DNS, or write to storage) to retrieve results.  
+6. (Optional) Leverage notebook execution to obtain **Managed Identity** tokens from the compute (e.g., `az login --identity --username $DEFAULT_IDENTITY_CLIENT_ID && az account get-access-token`) and pivot to other resources.
+
+**Related Tooling**
+
+- **MicroBurst** `Get-AzMachineLearningCredentials` gathers AML workspace **datastore credentials** and default datastore keys via the management plane API (subject to current service permissions).
+
+**Detections**
+
+*Storage / Data Plane*
+
+- **Azure Activity Log** for **Storage Accounts**: monitor `Microsoft.Storage/storageAccounts/listKeys/action` preceding notebook file modifications.  
+- **Azure Files** (Diagnostic Settings): alert on **writes** to `.ipynb` in the notebook share (e.g., `code/`).
+
+*AML Management Plane*
+
+- **Azure Activity Log** for AML: monitor `Microsoft.MachineLearningServices/workspaces/listKeys/action` (workspace list secrets/keys).  
+- Watch for API calls to AML **datastore** endpoints returning secrets/keys (names may vary; verify in your tenant’s diagnostics).
+
+*Example query ideas* (pseudocode / KQL-style; adjust to your tables):
+
+```text
+// Storage account key listings
+AzureActivity
+| where OperationNameValue == "Microsoft.Storage/storageAccounts/listKeys/action"
+| summarize count() by Caller, ResourceGroup, _ResourceId, bin(TimeGenerated, 1h)
+
+// Azure Files writes to notebooks (requires Storage logging to Log Analytics)
+StorageFileLogs
+| where Uri endswith ".ipynb" and OperationName has_any ("PutRange","PutFile","SetProperties","Create")
+| summarize writes=count() by AccountName, ShareName, Path, bin(TimeGenerated, 15m)
+```
+
+**Mitigations**
+
+- **Least privilege**: restrict Storage Account write roles; avoid broad Contributor and key access.  
+- **Key hygiene**: disable **account key** usage where possible; favor **RBAC** with Azure AD; rotate keys/SAS tokens.  
+- **Network controls**: use **Private Endpoints**; limit who can reach Storage and AML compute; restrict egress from compute as appropriate.  
+- **Process controls**: require **code review** for notebooks; disallow automated **Run all** without approvals; scan notebooks for unexpected hidden cells.  
+- **Logging**: enable **Diagnostic Settings** on Storage (Azure Files) and AML; alert on **listKeys** and on notebook file writes.
+
+**Additional Resources**
+
+- NetSPI: *Hijacking Azure Machine Learning Notebooks (via Storage Accounts)* – https://www.netspi.com/blog/technical-blog/cloud-pentesting/hijacking-azure-machine-learning-notebooks/
+- MicroBurst `Get-AzMachineLearningCredentials` – https://github.com/NetSPI/MicroBurst/blob/master/Az/Get-AzMachineLearningCredentials.ps1
+- Microsoft Docs: *Run Jupyter notebooks in your workspace* – https://learn.microsoft.com/azure/machine-learning/how-to-run-jupyter-notebooks
+- Microsoft Docs: *Manage roles in your workspace (RBAC)* – https://learn.microsoft.com/azure/machine-learning/how-to-assign-roles
+- Microsoft Docs: *Set up authentication (SDK/CLI)* – https://learn.microsoft.com/azure/machine-learning/how-to-setup-authentication

--- a/docs/Execution/AZT304/AZT304.md
+++ b/docs/Execution/AZT304/AZT304.md
@@ -1,0 +1,12 @@
+[AZT304.md](https://github.com/user-attachments/files/22000774/AZT304.md)
+# AZT304 - Hijack Azure Machine Learning Notebooks (via Storage Accounts)
+
+> Note: **AZT304** follows the Execution tactic numbering. Maintainers may still renumber or relocate this entry.
+
+An adversary may achieve **code execution** in Azure Machine Learning (AML) by modifying Jupyter **notebook files** stored in the AML workspace’s **backing Storage Account (Azure Files “code” share)**. AML Studio maps this file share directly to the notebook UI. If an attacker has **read/write access** to that Storage Account (e.g., via RBAC or account keys), they can inject hidden or overt code cells into `.ipynb` files. Execution occurs when users click **Run all** or when notebooks run as part of **pipelines/scheduled jobs**, yielding code execution within AML compute.
+
+A now-remediated issue previously allowed the **Reader** role on AML to obtain **Storage Account keys** for the workspace’s default datastore endpoints, enabling notebook modification and execution. Public tooling also enables dumping AML datastore credentials from the management plane, facilitating further credential access.
+
+ID | Name | Description | Action | Resources
+---|---|---|---|---
+AZT304.1 | Storage Account Notebook Overwrite | Modify `.ipynb` files in the AML workspace’s Storage Account (Azure Files) to inject code that executes in user sessions or pipelines. | N/A (data plane file write) | Machine Learning, Storage Account (Azure Files)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,8 @@ nav:
                 - AZT302.3 - Automation Account Runbook Managed Identity: Execution/AZT302/AZT302-3.md               
                 - AZT302.4 - Function Application: Execution/AZT302/AZT302-4.md
                 - AZT303 - Managed Device Scripting: Execution/AZT303/AZT303.md
+                - AZT304 - Hijack Azure Machine Learning Notebooks (via Storage Accounts): Execution/AZT304/AZT304.md
+                - AZT304.1 - Storage Account Notebook Overwrite: Execution/AZT304/AZT304-1.md
         - 'Privilege Escalation':
             - 'Privilege Escalation': PrivilegeEscalation/PrivEsc.md
             - Techniques:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,8 @@ nav:
                 - AZT605.1 - Storage Account Access Key Dumping: CredentialAccess/AZT605/AZT605-1.md
                 - AZT605.2 - Automation Account Credential Secret Dump: CredentialAccess/AZT605/AZT605-2.md
                 - AZT605.3 - Resource Group Deployment History Secret Dump: CredentialAccess/AZT605/AZT605-3.md
+                - AZT606 - Steal App Service Easy Auth Tokens: CredentialAccess/AZT606/AZT606.md
+                - AZT606.1 - App Service Token File Decryption (Kudu): CredentialAccess/AZT606/AZT606-1.md
         - Impact:
             - Impact: Impact/Impact.md
             - Techniques:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,8 @@ nav:
                 - AZT605.3 - Resource Group Deployment History Secret Dump: CredentialAccess/AZT605/AZT605-3.md
                 - AZT606 - Steal App Service Easy Auth Tokens: CredentialAccess/AZT606/AZT606.md
                 - AZT606.1 - App Service Token File Decryption (Kudu): CredentialAccess/AZT606/AZT606-1.md
+                - AZT607 - Extract Azure Load Testing Secrets and Tokens: CredentialAccess/AZT607/AZT607.md
+                - AZT607.1 - JMeter/Locust Code Execution to Extract Secrets/Tokens: CredentialAccess/AZT607/AZT607-1.md
         - Impact:
             - Impact: Impact/Impact.md
             - Techniques:

--- a/site/acknowledgments/index.html
+++ b/site/acknowledgments/index.html
@@ -2142,6 +2142,7 @@
 <li>Nikhil Mittal <a href="https://twitter.com/nikhil_mitt"><span class="twemoji twitter"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Free 6.1.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc.--><path d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"/></svg></span></a> </li>
 <li><a href="https://attack.mitre.org/resources/terms-of-use/">MITRE ATT&amp;CK</a> - © 2021 The MITRE Corporation. This work is reproduced and distributed with the permission of The MITRE Corporation.</li>
 <li><a href="https://alertiq.io/">AlertIQ</a></li>
+<li>Jiraput Thamsongkrah (swzhouu)</li>
 </ul>
 
               


### PR DESCRIPTION
Title: Add AZT606 – Steal App Service Easy Auth Tokens (Kudu decryption)

This PR proposes a new Credential Access family for stealing Azure App Service Easy Auth tokens, with an initial sub-technique covering token file decryption via the SCM/Kudu site.
- Adds `docs/CredentialAccess/AZT606/AZT606.md` (family overview)
- Adds `docs/CredentialAccess/AZT606/AZT606-1.md` (App Service Token File Decryption via Kudu)

Notes:
- AZT606 is a placeholder ID; feel free to renumber or relocate.
- Content references publicly available research (NetSPI, Daze Security) and Microsoft documentation; no proprietary details included.